### PR TITLE
Hotfix to change @Autowired to @Bean for processMessage()

### DIFF
--- a/src/main/kotlin/offtop/sessionReportService/Listeners/EndSessionConsumer.kt
+++ b/src/main/kotlin/offtop/sessionReportService/Listeners/EndSessionConsumer.kt
@@ -5,6 +5,7 @@ import offtop.sessionReportService.Services.EndSessionConsumerService
 import org.apache.kafka.streams.StreamsBuilder
 import org.apache.kafka.streams.kstream.KStream
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
 import org.springframework.stereotype.Service
 
 @Service
@@ -23,7 +24,7 @@ class EndSessionConsumer {
 
     var topic = "EndSession"
 
-    @Autowired
+    @Bean
     fun processMessage() {
         val streamsBuilder = StreamsBuilder()
 

--- a/src/main/kotlin/offtop/sessionReportService/Services/DataProcessingService.kt
+++ b/src/main/kotlin/offtop/sessionReportService/Services/DataProcessingService.kt
@@ -15,8 +15,7 @@ class DataProcessingService {
         var i: Double = 0.0
         var score: Double = 0.0
         pointer.session_data.indices.forEach { value: Int ->
-            score +=
-                    pointer.session_data[value].focus_value
+            score += pointer.session_data[value].focus_value
             i++
         }
         return score / i


### PR DESCRIPTION
Instead of using @Autowired in processMessage() for EndSessionConsumer, it will be using @Bean instead 