### PR TITLE
OT-ContainerizeSessionReport | Put session report into a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM adoptopenjdk/openjdk11
+COPY target/sessionReportService-0.0.1-SNAPSHOT.jar SessionReportService-0.0.1-SNAPSHOT.jar
+EXPOSE 8030
+ENTRYPOINT ["java","-jar","SessionReportService-0.0.1-SNAPSHOT.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  session-report:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    image: session-report:1.0
+    ports:
+      - 8030:8030
+
+networks:
+  default:
+    external:
+      name: offtop-network

--- a/src/main/kotlin/offtop/sessionReportService/Config/KafkaStreamsFactory.kt
+++ b/src/main/kotlin/offtop/sessionReportService/Config/KafkaStreamsFactory.kt
@@ -12,7 +12,10 @@ class KafkaStreamsFactory {
         val topology: Topology = streamsBuilder.build()
 
         val props = Properties()
-        props["bootstrap.servers"] = "localhost:9092"
+        //UNCOMMENT THE LINE BELOW IF YOU WANT TO USE DOCKER KAFKA
+        props["bootstrap.servers"] = "kafka:9092"
+        //UNCOMMENT THE LINE BELOW IF YOU WANT TO USE LOCAL KAFKA
+        //props["bootstrap.servers"] = "localhost:9092"  
         props["application.id"] = "report"
 
         val streams = KafkaStreams(topology, props)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,12 +1,20 @@
-#Kafka Consumer Settings
 server.port=8030
-spring.kafka.consumer.bootstrap-servers=localhost:9092
+
+#Kafka Consumer Settings
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE DOCKER KAFKA
+spring.kafka.consumer.bootstrap-servers=kafka:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE LOCAL KAFKA
+#spring.kafka.consumer.bootstrap-servers=localhost:9092
 spring.kafka.consumer.auto-offset-reset=earliest
 spring.kafka.consumer.group-id=report
 spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+
 #Kafka Producer Settings
-spring.kafka.producer.bootstrap-servers=localhost:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE DOCKER KAFKA
+spring.kafka.producer.bootstrap-servers=kafka:9092
+##UNCOMMENT THE LINE BELOW IF YOU WANT TO USE LOCAL KAFKA
+#spring.kafka.producer.bootstrap-servers=localhost:9092
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
 #set topics to false if topic is not created


### PR DESCRIPTION
**What I Did:**
- Used Docker to put Session Report into a container
- Connected the containerized Session Report with a containerized Kafka 

**How to Test:**
- Make sure that you are able to connect to the containerized Kafka/Zookeeper server. The instructions can be found here: https://docs.google.com/document/d/1r5LvXN-08kG8zBy7SFDBJ_80pMHdjJU8RrkNpSqQzAs/edit: 
- Follow the instructions here to set up the containerized Session Report: https://docs.google.com/document/d/1eINs8K4ZgbX-AVd5K03-gerbFhluXbgiStBIWiM-jWE/edit?usp=sharing
- If you are able to get these two steps working, then Session Report is containerized.
- Revert back to using localhost for `application.properties` and `src\main\kotlin\offtop\sessionReportService\Config\KafkaStreamsFactory.kt `
- Run Session Report with `mvn spring-boot:run` and test with these [instructions](https://github.com/Off-Top-App/SessionReport/pull/2) to verify that Session Report is still working as intended.